### PR TITLE
reduce locator size

### DIFF
--- a/nibi/lib/libnibi/ref.hpp
+++ b/nibi/lib/libnibi/ref.hpp
@@ -43,7 +43,7 @@ public:
 
   T &operator*() const { return *object_; }
 
-  T* get() const { return object_; }
+  T *get() const { return object_; }
 
   bool operator==(const ref_counted_ptr_c &rhs) const {
     return object_ == rhs.object_;

--- a/nibi/lib/libnibi/ref.hpp
+++ b/nibi/lib/libnibi/ref.hpp
@@ -43,6 +43,8 @@ public:
 
   T &operator*() const { return *object_; }
 
+  T* get() const { return object_; }
+
   bool operator==(const ref_counted_ptr_c &rhs) const {
     return object_ == rhs.object_;
   }

--- a/nibi/lib/libnibi/source.hpp
+++ b/nibi/lib/libnibi/source.hpp
@@ -5,10 +5,12 @@
 #include <tuple>
 #include <unordered_map>
 
+#include "libnibi/ref.hpp"
+
 namespace nibi {
 //! \brief A locator interface.
 //!       Used to locate errors in the source.
-class locator_if {
+class locator_if : public ref_counted_c {
 public:
   virtual ~locator_if() = default;
   virtual const size_t get_line() const = 0;
@@ -18,7 +20,7 @@ public:
 };
 
 // Shorthand for a shared locator interface pointer.
-using locator_ptr = std::shared_ptr<locator_if>;
+using locator_ptr = nibi::ref_counted_ptr_c<locator_if>;
 
 extern void draw_locator(locator_if &location);
 
@@ -64,7 +66,7 @@ public:
   std::string get_source_name() { return *source_name_; }
   //! \brief Get a locator interface for the source.
   locator_ptr get_locator(const size_t line, const size_t column) const {
-    return std::make_shared<locator_c>(source_name_, line, column);
+    return new locator_c(source_name_, line, column);
   }
 
 private:


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [X] Branch name details the work done for the PR
- [X] CI tests have passed
- [X] An admin has reviewed and accepted the PR
- [X] Clang format has been run on changes (`run ./tools/format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Unions end in `_u`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)
- Type names that define a particular type of pointer end in `_ptr`

The above is just a loose formatting that has been used already throughout the C++ source code of Nibi,
and we would like to keep things mostly uniform. In the future, an actual style guide may be created. 

## Description of work:

Please enter a description of your work here:
```
Reduced cell size by ~8 bytes by using the ref_counted_ptr impl instead of the std::shared_ptr. 
```
