### PR TITLE
114.flatten cell c

### DIFF
--- a/docs/BENCH.md
+++ b/docs/BENCH.md
@@ -223,3 +223,25 @@ down.
 | 4sieve.nibi     | 0.6773s   | 677.348ms  |
 | leibniz.nibi    | 0.0778s   | 77.7946ms  |
 
+### 31-July-2023
+
+git hash **6a0a648b2726a467e9aca5ce89473a86f105843f**
+
+Issue 114: Flatten cell_c
+
+This is the final commit of the "make cell_c" not bloated work.
+Cell_c started off at 56 bytes (MASSIVE) and is now down to 
+29 (still not small.) 
+
+Cells currently take so much memory as there is 
+overhead for RAII, and source locators. However, 
+soon cell_c will not be the actual `running` instructions
+and the actual processed bytecode/atoms will be
+able to exist without RAII and locators (most likely.)
+
+| test            | time (s)  | time (ms)
+|----             |----       |----
+| mandelbrot.nibi | 0.0761s   | 76.1015ms  |
+| primality.nibi  | 0.671s    | 670.9686ms |
+| 4sieve.nibi     | 0.6626s   | 662.5976ms |
+| leibniz.nibi    | 0.0728s   | 72.813ms   |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -91,9 +91,6 @@ any other piece of data in the instructions below.
 | mem-del | Delete some memory on the heap | Pointer cell |
 | mem-cpy | Copy a trivial cell's data to heap, or copy a pointer cell | Destination pointer cell |
 | mem-load | Load a data from heap into a new cell | New cell of trivial cell type |
-| mem-owned | Check if memory is owned by the nibi runtime, or by an external lib | T/F |
-| mem-acquire | Declare that an unowned pointer is owned | The owned pointer |
-| mem-abandon | Declare that the pointer is not owned by nibi runtime | The pointer |
 | mem-is-set | Check if a cell pointer has its pointer set to a space in memory | T/F |
 
 | list commands | description | returns
@@ -1027,10 +1024,6 @@ Keyword: `mem-cpy`
 
 Copy data in memory. If the first item is a standard "trival" cell. That is, one that has
 a direct C-Type integration, it will be copied to the heap at a given destination pointer.
-For this to succeed the destination pointer must be `owned`.
-
-If the first item is a pointer cell, the data will be copied to the destination if and only
-if the source and destination pointer are `owned`. 
 
 Example:
 
@@ -1057,38 +1050,9 @@ Attempt to load a value from memory as a regular, trivial, cell.
 The load command requires the first argument to be a cell `type tag` (mentioned above) that will
 indicate how much space to load from memory, and how to represent it as a cell.
 
-The second parameter must be a ptr cell. This ptr cell does not need to be owned for the operation
-to take place.
-
 ```lisp
 
 (:= result (mem-load :u64 my_ptr_cell))
-
-```
-
-Keyword: `mem-owned`
-
-Check of the given ptr cell is owned by the nibi runtime. Returns true/false
-
-Keyword: `mem-acquire`
-
-Mark a given ptr cell as being owned by nibi runtime. By default, if a pointer cell is made via mem-new
-it is considered owned. If the pointer comes from an external source, it is not owned. 
-
-Acquiring ownership of the pointer should only be done if the external source expects the caller to 
-manage the resource's lifetime.
-
-Deleting a manually acquired pointer value may cause UB.
-
-Keyword: `mem-abandon`
-
-Mark any N number of pointers as no longer owned by the runtime. Runtime will not be able to delete the pointer
-unless it is later re-acquired. This is meant to be done after moving ownership of data to an external
-source and indicating to the runtime that the pointer is now externally managed.
-
-```lisp
-
-(mem-abandon a b c d e)
 
 ```
 

--- a/nibi/lib/libnibi/cell.cpp
+++ b/nibi/lib/libnibi/cell.cpp
@@ -85,7 +85,16 @@ cell_c::~cell_c() {
     if (func_info.type == function_type_e::FAUX) {
       if (func_info.operating_env) {
         delete func_info.operating_env;
+        func_info.operating_env = nullptr;
       }
+    }
+    break;
+  }
+  case cell_type_e::SYMBOL:
+  case cell_type_e::STRING: {
+    if (this->data.cstr) {
+      delete[] this->data.cstr;
+      this->data.cstr = nullptr;
     }
     break;
   }

--- a/nibi/lib/libnibi/cell.cpp
+++ b/nibi/lib/libnibi/cell.cpp
@@ -88,6 +88,8 @@ cell_c::~cell_c() {
         func_info.operating_env = nullptr;
       }
     }
+    delete this->data.fn;
+    this->data.fn = nullptr;
     break;
   }
   case cell_type_e::SYMBOL:
@@ -180,8 +182,9 @@ cell_ptr cell_c::clone(env_c &env) {
 
     auto &func_info = this->as_function_info();
 
-    new_cell->complex_data =
-        function_info_s(func_info.name, func_info.fn, func_info.type);
+    new_cell->data.fn->name = func_info.name;
+    new_cell->data.fn->fn = func_info.fn;
+    new_cell->data.fn->type = func_info.type;
 
     if (func_info.type == function_type_e::FAUX) {
       if (func_info.operating_env) {

--- a/nibi/lib/libnibi/cell.cpp
+++ b/nibi/lib/libnibi/cell.cpp
@@ -98,6 +98,12 @@ cell_c::~cell_c() {
     }
     break;
   }
+  case cell_type_e::ENVIRONMENT: {
+    if (this->data.env) {
+      delete this->data.env;
+      this->data.env = nullptr;
+    }
+  }
   default: {
     break;
   }

--- a/nibi/lib/libnibi/cell.cpp
+++ b/nibi/lib/libnibi/cell.cpp
@@ -173,8 +173,6 @@ cell_ptr cell_c::clone(env_c &env) {
     break;
   case cell_type_e::PTR: {
     new_cell->data.ptr = this->data.ptr;
-    auto &pi = this->as_pointer_info();
-    new_cell->complex_data = pointer_info_s{pi.is_owned, pi.size_bytes};
     break;
   }
   case cell_type_e::ALIAS: {

--- a/nibi/lib/libnibi/cell.cpp
+++ b/nibi/lib/libnibi/cell.cpp
@@ -106,6 +106,20 @@ cell_c::~cell_c() {
       this->data.env = nullptr;
     }
   }
+  case cell_type_e::ALIAS: {
+    if (this->data.alias) {
+      delete this->data.alias;
+      this->data.alias = nullptr;
+    }
+    break;
+  }
+  case cell_type_e::DICT: {
+    if (this->data.dict) {
+      delete this->data.dict;
+      this->data.dict = nullptr;
+    }
+    break;
+  }
   default: {
     break;
   }

--- a/nibi/lib/libnibi/cell.cpp
+++ b/nibi/lib/libnibi/cell.cpp
@@ -120,6 +120,13 @@ cell_c::~cell_c() {
     }
     break;
   }
+  case cell_type_e::LIST: {
+    if (this->data.list) {
+      delete this->data.list;
+      this->data.list = nullptr;
+    }
+    break;
+  }
   default: {
     break;
   }

--- a/nibi/lib/libnibi/cell.hpp
+++ b/nibi/lib/libnibi/cell.hpp
@@ -128,6 +128,10 @@ using cell_dict_t = std::unordered_map<std::string, cell_ptr>;
 
 struct dict_info_s {
   cell_dict_t data;
+
+  dict_info_s() = default;
+  dict_info_s(const dict_info_s &other) : data(other.data){};
+  dict_info_s(cell_dict_t other) : data(std::move(other)){};
 };
 
 //! \brief Lambda information that can be encoded into a cell

--- a/nibi/lib/libnibi/cell.hpp
+++ b/nibi/lib/libnibi/cell.hpp
@@ -173,7 +173,7 @@ struct symbol_s {
 
 // Temporary wrapper to distinguish aliases
 struct alias_s {
-  cell_ptr data;
+  cell_ptr cell;
 };
 
 //! \brief Environment information that can be encoded into a cell
@@ -277,6 +277,7 @@ public:
     aberrant_cell_if *aberrant;
     environment_info_s *env;
     function_info_s *fn;
+    alias_s *alias;
   } data{0};
 
   std::any complex_data{0};
@@ -297,7 +298,7 @@ public:
     update_string(data.data);
   }
   cell_c(alias_s alias) : type(cell_type_e::ALIAS) {
-    this->complex_data = alias.data;
+    this->data.alias = new alias_s(alias);
   }
 
   cell_c(list_info_s list) : type(cell_type_e::LIST) { complex_data = list; }
@@ -573,11 +574,10 @@ public:
   }
 
   cell_ptr get_alias() const {
-    try {
-      return std::any_cast<cell_ptr>(this->complex_data);
-    } catch (const std::bad_any_cast &e) {
+    if (this->type != cell_type_e::ALIAS) {
       throw cell_access_exception_c("Cell is not an alias", this->locator);
     }
+    return this->data.alias->cell;
   }
 
   //! \brief Check if a cell is an integer

--- a/nibi/lib/libnibi/cell.hpp
+++ b/nibi/lib/libnibi/cell.hpp
@@ -128,7 +128,6 @@ using cell_dict_t = std::unordered_map<std::string, cell_ptr>;
 
 struct dict_info_s {
   cell_dict_t data;
-
   dict_info_s() = default;
   dict_info_s(const dict_info_s &other) : data(other.data){};
   dict_info_s(cell_dict_t other) : data(std::move(other)){};
@@ -188,16 +187,6 @@ struct alias_s {
 struct environment_info_s {
   std::string name;
   std::shared_ptr<env_c> env{nullptr};
-};
-
-//! \brief Pointer information
-struct pointer_info_s {
-  bool is_owned{false};
-  // In the event of getting something from ffi we wont know
-  // the size. So even if we acquire ownership, we may not
-  // have access to this. We keep the size for what
-  // we create so we can bound check
-  std::optional<std::size_t> size_bytes{std::nullopt};
 };
 
 //! \brief An exception that is thrown when a cell is accessed
@@ -375,7 +364,6 @@ public:
       break;
     case cell_type_e::PTR:
       this->data.ptr = nullptr;
-      this->complex_data = pointer_info_s{false, 0};
       break;
     case cell_type_e::STRING:
     case cell_type_e::SYMBOL:
@@ -542,15 +530,6 @@ public:
     }
 
     return *(this->data.env);
-  }
-
-  pointer_info_s &as_pointer_info() {
-    try {
-      return std::any_cast<pointer_info_s &>(this->complex_data);
-    } catch (const std::bad_any_cast &e) {
-      throw cell_access_exception_c("Cell does not contain a pointer",
-                                    this->locator);
-    }
   }
 
   void *as_pointer() const {

--- a/nibi/lib/libnibi/cell.hpp
+++ b/nibi/lib/libnibi/cell.hpp
@@ -437,7 +437,13 @@ public:
     return this->data.cstr;
   }
 
-  char *as_c_string() { return &*as_string().begin(); }
+  char *as_c_string() {
+    if (this->type != cell_type_e::STRING &&
+        this->type != cell_type_e::SYMBOL) {
+      throw cell_access_exception_c("Cell does not contain a string, or a symbol", this->locator);
+    }
+    return this->data.cstr;
+  }
 
   std::string as_symbol() {
     if (this->type != cell_type_e::SYMBOL) {

--- a/nibi/lib/libnibi/environment.hpp
+++ b/nibi/lib/libnibi/environment.hpp
@@ -8,6 +8,7 @@
 #include <map>
 
 namespace nibi {
+
 //! \brief The environment object that will be used to store
 //!        and manage the cells that are used in different scopes
 class env_c {

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
@@ -246,17 +246,8 @@ static function_info_s builtin_memory_cpy_inf = {
 static function_info_s builtin_memory_load_inf = {
     nibi::kw::MEM_LOAD, builtin_fn_memory_load,
     function_type_e::BUILTIN_CPP_FUNCTION};
-static function_info_s builtin_memory_owned_inf = {
-    nibi::kw::MEM_OWNED, builtin_fn_memory_owned,
-    function_type_e::BUILTIN_CPP_FUNCTION};
-static function_info_s builtin_memory_acquire_inf = {
-    nibi::kw::MEM_ACQUIRE, builtin_fn_memory_acquire,
-    function_type_e::BUILTIN_CPP_FUNCTION};
 static function_info_s builtin_memory_is_set_inf = {
     nibi::kw::MEM_IS_SET, builtin_fn_memory_is_set,
-    function_type_e::BUILTIN_CPP_FUNCTION};
-static function_info_s builtin_memory_abandon_inf = {
-    nibi::kw::MEM_ABANDON, builtin_fn_memory_abandon,
     function_type_e::BUILTIN_CPP_FUNCTION};
 
 // This map is used to look up the function info struct for a given symbol
@@ -331,9 +322,6 @@ static function_router_t keyword_map = {
     {nibi::kw::MEM_DEL, builtin_memory_del_inf},
     {nibi::kw::MEM_CPY, builtin_memory_cpy_inf},
     {nibi::kw::MEM_LOAD, builtin_memory_load_inf},
-    {nibi::kw::MEM_OWNED, builtin_memory_owned_inf},
-    {nibi::kw::MEM_ACQUIRE, builtin_memory_acquire_inf},
-    {nibi::kw::MEM_ABANDON, builtin_memory_abandon_inf},
     {nibi::kw::MEM_IS_SET, builtin_memory_is_set_inf}};
 
 // Retrieve the map of symbols to function info structs

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
@@ -198,12 +198,6 @@ extern cell_ptr builtin_fn_memory_cpy(cell_processor_if &ci, cell_list_t &list,
                                       env_c &env);
 extern cell_ptr builtin_fn_memory_load(cell_processor_if &ci, cell_list_t &list,
                                        env_c &env);
-extern cell_ptr builtin_fn_memory_owned(cell_processor_if &ci,
-                                        cell_list_t &list, env_c &env);
-extern cell_ptr builtin_fn_memory_acquire(cell_processor_if &ci,
-                                          cell_list_t &list, env_c &env);
-extern cell_ptr builtin_fn_memory_abandon(cell_processor_if &ci,
-                                          cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_memory_is_set(cell_processor_if &ci,
                                          cell_list_t &list, env_c &env);
 

--- a/nibi/lib/libnibi/interpreter/builtins/environment_modifiers.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/environment_modifiers.cpp
@@ -17,13 +17,13 @@ cell_ptr builtin_fn_env_alias(cell_processor_if &ci, cell_list_t &list,
   NIBI_LIST_ENFORCE_SIZE(nibi::kw::ALIAS, ==, 3)
 
   auto alias_target = ci.process_cell(list[1], env);
-  auto target_variable_name = list[2]->as_symbol();
+  auto target_variable_name = list[2]->as_c_string();
 
   NIBI_VALIDATE_VAR_NAME(target_variable_name, list[2]->locator);
 
   if (list[1]->type == cell_type_e::SYMBOL) {
-    auto source_variable_name = list[1]->as_symbol();
-    if (source_variable_name == target_variable_name) {
+    auto source_variable_name = list[1]->as_c_string();
+    if (::strcmp(source_variable_name, target_variable_name) == 0) {
       throw interpreter_c::exception_c("Cannot alias a variable to itself",
                                        list[1]->locator);
     }
@@ -50,7 +50,7 @@ cell_ptr builtin_fn_env_assignment(cell_processor_if &ci, cell_list_t &list,
         "Expected symbol as first argument to assign", (*it)->locator);
   }
 
-  auto target_variable_name = (*it)->as_symbol();
+  auto target_variable_name = (*it)->as_c_string();
 
   NIBI_VALIDATE_VAR_NAME(target_variable_name, (*it)->locator);
 

--- a/nibi/lib/libnibi/interpreter/builtins/environment_modifiers.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/environment_modifiers.cpp
@@ -17,7 +17,7 @@ cell_ptr builtin_fn_env_alias(cell_processor_if &ci, cell_list_t &list,
   NIBI_LIST_ENFORCE_SIZE(nibi::kw::ALIAS, ==, 3)
 
   auto alias_target = ci.process_cell(list[1], env);
-  auto &target_variable_name = list[2]->as_symbol();
+  auto target_variable_name = list[2]->as_symbol();
 
   NIBI_VALIDATE_VAR_NAME(target_variable_name, list[2]->locator);
 
@@ -50,7 +50,7 @@ cell_ptr builtin_fn_env_assignment(cell_processor_if &ci, cell_list_t &list,
         "Expected symbol as first argument to assign", (*it)->locator);
   }
 
-  auto &target_variable_name = (*it)->as_symbol();
+  auto target_variable_name = (*it)->as_symbol();
 
   NIBI_VALIDATE_VAR_NAME(target_variable_name, (*it)->locator);
 

--- a/nibi/lib/libnibi/interpreter/builtins/lambdas.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/lambdas.cpp
@@ -23,7 +23,7 @@ cell_ptr execute_suspected_lambda(cell_processor_if &ci, cell_list_t &list,
 
   // If the first argument is a symbol, then we need to look it up
   if ((*it)->type == cell_type_e::SYMBOL) {
-    auto target_symbol = (*it)->as_symbol();
+    auto target_symbol = (*it)->as_c_string();
     target_cell = env.get(target_symbol);
     if (!target_cell) {
       throw interpreter_c::exception_c("Symbol not found in environment: " +

--- a/nibi/lib/libnibi/keywords.hpp
+++ b/nibi/lib/libnibi/keywords.hpp
@@ -74,9 +74,6 @@ static constexpr const char *MEM_NEW = "mem-new";
 static constexpr const char *MEM_DEL = "mem-del";
 static constexpr const char *MEM_CPY = "mem-cpy";
 static constexpr const char *MEM_LOAD = "mem-load";
-static constexpr const char *MEM_OWNED = "mem-owned";
-static constexpr const char *MEM_ACQUIRE = "mem-acquire";
-static constexpr const char *MEM_ABANDON = "mem-abandon";
 static constexpr const char *MEM_IS_SET = "mem-is-set";
 static constexpr const char *ALIAS = "alias";
 

--- a/nibi/lib/libnibi/macros.hpp
+++ b/nibi/lib/libnibi/macros.hpp
@@ -33,5 +33,4 @@ namespace nibi {
         list.front()->locator);                                                \
     return nibi::allocate_cell(nibi::cell_type_e::NIL);                        \
   }
-
 } // namespace nibi

--- a/nibi/modules/meta/export.nibi
+++ b/nibi/modules/meta/export.nibi
@@ -1,1 +1,2 @@
 (alias {meta meta_cell} meta::cell)
+(alias {meta meta_locator} meta::locator)

--- a/nibi/modules/meta/lib.cpp
+++ b/nibi/modules/meta/lib.cpp
@@ -7,3 +7,8 @@ nibi::cell_ptr meta_cell(nibi::cell_processor_if &ci, nibi::cell_list_t &list,
                          nibi::env_c &env) {
   return nibi::allocate_cell((int64_t)sizeof(nibi::cell_c));
 }
+
+nibi::cell_ptr meta_locator(nibi::cell_processor_if &ci,
+                            nibi::cell_list_t &list, nibi::env_c &env) {
+  return nibi::allocate_cell((int64_t)sizeof(nibi::locator_ptr));
+}

--- a/nibi/modules/meta/lib.hpp
+++ b/nibi/modules/meta/lib.hpp
@@ -13,4 +13,7 @@ extern "C" {
 API_EXPORT
 extern nibi::cell_ptr meta_cell(nibi::cell_processor_if &ci,
                                 nibi::cell_list_t &list, nibi::env_c &env);
+API_EXPORT
+extern nibi::cell_ptr meta_locator(nibi::cell_processor_if &ci,
+                                   nibi::cell_list_t &list, nibi::env_c &env);
 }

--- a/nibi/modules/meta/mod.nibi
+++ b/nibi/modules/meta/mod.nibi
@@ -11,6 +11,7 @@
 
 (:= dylib [
   "meta_cell"
+  "meta_locator"
 ])
 
 (:= post [

--- a/tests/test_scripts/run.py
+++ b/tests/test_scripts/run.py
@@ -47,8 +47,11 @@ def test_item(id, expected_result, item):
    end = time.time()
    parser_status = True
 
-   decoded = result.stdout.decode("utf-8")
-
+   try:
+      decoded = result.stdout.decode("utf-8")
+   except:
+      print("Failed to decode output: ", str(result))
+      exit(1)
    results["name"] = item
 
    results["result"] = {

--- a/tests/test_scripts/tests/0_memory.nibi
+++ b/tests/test_scripts/tests/0_memory.nibi
@@ -4,18 +4,10 @@
 
 (assert (eq true (mem-is-set x)))
 
-(assert (eq true (mem-owned x)))
-
-(mem-abandon x)
-
-(assert (eq false (mem-owned x)))
-
 (try [
   (mem-del x)
   (assert (eq true false) "Able to free non-owned memory")
 ] (nop) )
-
-(mem-acquire x)
 
 (mem-del x)
 
@@ -28,7 +20,6 @@
 (mem-cpy x y)
 
 (assert (eq true (mem-is-set y)))
-(assert (eq true (mem-owned y)))
 
 (mem-del y)
 (mem-del x)
@@ -39,7 +30,6 @@
 (mem-cpy x y)
 
 (assert (eq true (mem-is-set y)))
-(assert (eq true (mem-owned y)))
 
 (:= a (mem-cpy (u8 100) (mem-new 8)))
 (:= b (mem-load :u8 a))

--- a/tests/test_scripts/tests/0_memory.nibi
+++ b/tests/test_scripts/tests/0_memory.nibi
@@ -4,11 +4,6 @@
 
 (assert (eq true (mem-is-set x)))
 
-(try [
-  (mem-del x)
-  (assert (eq true false) "Able to free non-owned memory")
-] (nop) )
-
 (mem-del x)
 
 (assert (eq false (mem-is-set x)))
@@ -17,12 +12,13 @@
 
 (:= y (mem-new nil))
 
-(mem-cpy x y)
+(mem-cpy x y 15)
 
 (assert (eq true (mem-is-set y)))
 
 (mem-del y)
 (mem-del x)
+
 
 (set x "Some string")
 (set y (mem-new nil))

--- a/tests/test_scripts/tests/0_try_throw.nibi
+++ b/tests/test_scripts/tests/0_try_throw.nibi
@@ -5,4 +5,4 @@
   (:= result $e)
 )
 
-(assert (eq message result) "Throw did not give the correct resultif!")
+(assert (eq message result) "Throw did not give the correct result")

--- a/tests/test_valgrind/manual_memory.nibi
+++ b/tests/test_valgrind/manual_memory.nibi
@@ -47,7 +47,7 @@
 
 
 (:= some_string "This is a new string")
-(:= c (mem-cpy some_string (mem-new (len some_string))))
+(:= c (mem-cpy some_string (mem-new (+ 1 (len some_string)))))
 (:= d (mem-load :str c))
 
 

--- a/tests/test_valgrind/manual_memory.nibi
+++ b/tests/test_valgrind/manual_memory.nibi
@@ -4,19 +4,6 @@
 
 (assert (eq true (mem-is-set x)))
 
-(assert (eq true (mem-owned x)))
-
-(mem-abandon x)
-
-(assert (eq false (mem-owned x)))
-
-(try [
-  (mem-del x)
-  (assert (eq true false) "Able to free non-owned memory")
-] (nop) )
-
-(mem-acquire x)
-
 (mem-del x)
 
 (assert (eq false (mem-is-set x)))
@@ -25,13 +12,13 @@
 
 (:= y (mem-new nil))
 
-(mem-cpy x y)
+(mem-cpy x y 15)
 
 (assert (eq true (mem-is-set y)))
-(assert (eq true (mem-owned y)))
 
 (mem-del y)
 (mem-del x)
+
 
 (set x "Some string")
 (set y (mem-new nil))
@@ -39,7 +26,6 @@
 (mem-cpy x y)
 
 (assert (eq true (mem-is-set y)))
-(assert (eq true (mem-owned y)))
 
 (:= a (mem-cpy (u8 100) (mem-new 8)))
 (:= b (mem-load :u8 a))
@@ -47,7 +33,7 @@
 
 
 (:= some_string "This is a new string")
-(:= c (mem-cpy some_string (mem-new (+ 1 (len some_string)))))
+(:= c (mem-cpy some_string (mem-new (len some_string))))
 (:= d (mem-load :str c))
 
 


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [X] Branch name details the work done for the PR
- [X] CI tests have passed
- [X] An admin has reviewed and accepted the PR
- [X] Clang format has been run on changes (`run ./tools/format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Unions end in `_u`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)
- Type names that define a particular type of pointer end in `_ptr`

The above is just a loose formatting that has been used already throughout the C++ source code of Nibi,
and we would like to keep things mostly uniform. In the future, an actual style guide may be created. 

## Description of work:

Please enter a description of your work here:
```
Flattened the cell_c object pretty substantially. Its about 1/2 the size it was before while maintaining the same functionality and still being 1-1 compatible with CFFI and no extra copies of data from C. 

I removed all data stored in the `std::any` in the cell and flattened it into raw pointers within the c_data union. bench shows slight improvement but its realistically about the same .

What was once `complex_data` is no more!
```
