### PR TITLE
remove old mem cmds

### DIFF
--- a/tools/syntax/nibi.vim
+++ b/tools/syntax/nibi.vim
@@ -39,7 +39,7 @@ syn match nibiKeyword '$args\|$e' contained
 syn match nibiFunc '\(eq\|>\|<\|neq\|<=\|>=\|and\|or\|not\|if\|+\|-\|*\|/\)' contained
 syn match nibiFunc '\(bw-and\|bw-or\|bw-xor\|bw-not\|bw-lsh\|bw-rsh\|<-\)' contained
 syn match nibiFunc '\(extern-call\|mem-new\|mem-del\|mem-cpy\|mem-load\)' contained
-syn match nibiFunc '\(mem-owned\|mem-acquire\|mem-abandon\|mem-is-set\)' contained
+syn match nibiFunc '\(mem-is-set\)' contained
 syn match nibiFunc ':=' contained
 syn match nibiFunc '<<|' contained
 syn match nibiFunc '|>>' contained


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [ ] Branch name details the work done for the PR
- [ ] CI tests have passed
- [ ] An admin has reviewed and accepted the PR
- [ ] Clang format has been run on changes (`run ./tools/format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Unions end in `_u`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)
- Type names that define a particular type of pointer end in `_ptr`

The above is just a loose formatting that has been used already throughout the C++ source code of Nibi,
and we would like to keep things mostly uniform. In the future, an actual style guide may be created. 

## Description of work:

Please enter a description of your work here:
```
update syntax file
```
