### PR TITLE
120.nibi strings

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -66,6 +66,7 @@ any other piece of data in the instructions below.
 | extern-call | Call a c-function from a shared library | variable
 | alias   | Use a new symbol to refer to the data behing another | nil
 | exchange | Update the value of a cell and return the old value of the cell | variable
+| str-set-at | Update a string by inserting a value at a given index (negative indexing permitted) | updated string
 
 | type commands | description | returns
 |----   |---- |----
@@ -100,7 +101,7 @@ any other piece of data in the instructions below.
 | >\|   | Push value to front of list | modified list cell
 | \|<   | Push value to back of list  | modified list cell
 | iter  | Iterate over a list         | iterated list
-| at    | Retrieve an index into a list | cell at given index
+| at    | Retrieve an index into a list (negative indexing permitted | cell at given index
 | <\|>  | Spawn a list of a given size with a given value | new list
 | <<\|  | Pop front | list given sans the first element
 | \|>>  | Pop back  | list given sans the last element

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -65,10 +65,12 @@ any other piece of data in the instructions below.
 | dict | Create a dictionary | the new dictionary
 | extern-call | Call a c-function from a shared library | variable
 | alias   | Use a new symbol to refer to the data behing another | nil
+| exchange | Update the value of a cell and return the old value of the cell | variable
 
 | type commands | description | returns
 |----   |---- |----
 | type    | Retrieve a string detailing the type of a given item | string
+| char    | Convert an integer into its char representation, or convert a string into a char type | char
 | str     | Convert an item to a string type | converted value 
 | int     | Convert an item to an integer type | converted value 
 | i8      | Convert an item to the integer type | converted value 
@@ -83,7 +85,7 @@ any other piece of data in the instructions below.
 | f32     | Convert an item to the float type | converted value 
 | f64     | Convert an item to the float type | converted value 
 | split   | Convert an item to a list comprised of the raw elements of the given variable | converted value 
-
+| str-lit | Convert a list into a direct string rather than just a string representation | new string
 
 | memory commands | description | returns
 |----   |---- |----

--- a/nibi/config.nibi
+++ b/nibi/config.nibi
@@ -16,7 +16,8 @@
   "std/lists.nibi"
   "std/dicts.nibi"
   "std/loops.nibi"
-  "std/match.nibi")
+  "std/match.nibi"
+  "std/strings.nibi")
 
 # This is a special symbol that is used to determine
 # whether or not the standard library has been loaded.

--- a/nibi/lib/libnibi/front/intake.cpp
+++ b/nibi/lib/libnibi/front/intake.cpp
@@ -1,4 +1,6 @@
 #include "intake.hpp"
+#include "libnibi/shared.hpp"
+
 #include <cassert>
 #include <iostream>
 #include <limits>
@@ -128,14 +130,8 @@ void intake_c::check_for_complete_expression() {
 }
 
 inline bool check_buffer(std::string &buffer, char c) {
-
-  static std::unordered_map<char, char> escape_map = {
-      {'n', '\n'},  {'t', '\t'},  {'r', '\r'}, {'a', '\a'},
-      {'b', '\b'},  {'v', '\v'},  {'?', '\?'}, {'"', '\"'},
-      {'\'', '\''}, {'\\', '\\'}, {'0', '\0'}};
-
-  auto it = escape_map.find(c);
-  if (it != escape_map.end()) {
+  auto it = shared::char_escape_map.find(c);
+  if (it != shared::char_escape_map.end()) {
     buffer += it->second;
     return true;
   }

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
@@ -174,6 +174,9 @@ static function_info_s builtin_common_macro_inf = {
 static function_info_s builtin_cvt_string_inf = {
     nibi::kw::STR, builtin_fn_cvt_to_string,
     function_type_e::BUILTIN_CPP_FUNCTION};
+static function_info_s builtin_cvt_string_lit_inf = {
+    nibi::kw::STR_LIT, builtin_fn_cvt_to_string_lit,
+    function_type_e::BUILTIN_CPP_FUNCTION};
 static function_info_s builtin_cvt_int_inf = {
     nibi::kw::INT, builtin_fn_cvt_to_integer,
     function_type_e::BUILTIN_CPP_FUNCTION};
@@ -302,6 +305,7 @@ static function_router_t keyword_map = {
     {nibi::kw::BW_XOR, builtin_bitwise_xor_inf},
     {nibi::kw::BW_NOT, builtin_bitwise_not_inf},
     {nibi::kw::STR, builtin_cvt_string_inf},
+    {nibi::kw::STR_LIT, builtin_cvt_string_lit_inf},
     {nibi::kw::INT, builtin_cvt_int_inf},
     {nibi::kw::I8, builtin_cvt_i8_inf},
     {nibi::kw::I16, builtin_cvt_i16_inf},

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
@@ -171,6 +171,9 @@ static function_info_s builtin_common_nop_inf = {
 static function_info_s builtin_common_macro_inf = {
     nibi::kw::NOP, builtin_fn_common_macro,
     function_type_e::BUILTIN_CPP_FUNCTION};
+static function_info_s builtin_common_exchange_inf = {
+    nibi::kw::EXCHANGE, builtin_fn_common_exchange,
+    function_type_e::BUILTIN_CPP_FUNCTION};
 
 // conversion functions
 
@@ -302,6 +305,7 @@ static function_router_t keyword_map = {
     {nibi::kw::QUOTE, builtin_common_quote_inf},
     {nibi::kw::NOP, builtin_common_nop_inf},
     {nibi::kw::MACRO, builtin_common_macro_inf},
+    {nibi::kw::EXCHANGE, builtin_common_exchange_inf},
     {nibi::kw::BW_LSH, builtin_bitwise_lsh_inf},
     {nibi::kw::BW_RSH, builtin_bitwise_rsh_inf},
     {nibi::kw::BW_AND, builtin_bitwise_and_inf},

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
@@ -65,6 +65,9 @@ static function_info_s builtin_drop_inf = {
     nibi::kw::DROP, builtin_fn_env_drop, function_type_e::BUILTIN_CPP_FUNCTION};
 static function_info_s builtin_fn_inf = {nibi::kw::FN, builtin_fn_env_fn,
                                          function_type_e::BUILTIN_CPP_FUNCTION};
+static function_info_s builtin_str_set_at_inf = {
+    nibi::kw::STR_SET_AT, builtin_fn_env_str_set_at,
+    function_type_e::BUILTIN_CPP_FUNCTION};
 static function_info_s builtin_dict_inf = {
     nibi::kw::DICT, builtin_fn_dict_fn, function_type_e::BUILTIN_CPP_FUNCTION};
 
@@ -275,6 +278,7 @@ static function_router_t keyword_map = {
     {nibi::kw::SET, builtin_set_inf},
     {nibi::kw::FN, builtin_fn_inf},
     {nibi::kw::DICT, builtin_dict_inf},
+    {nibi::kw::STR_SET_AT, builtin_str_set_at_inf},
     {nibi::kw::DROP, builtin_drop_inf},
     {nibi::kw::TRY, builtin_try_inf},
     {nibi::kw::THROW, builtin_throw_inf},

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
@@ -149,6 +149,8 @@ extern cell_ptr builtin_fn_comparison_not(cell_processor_if &ci,
 
 extern cell_ptr builtin_fn_cvt_to_string(cell_processor_if &ci,
                                          cell_list_t &list, env_c &env);
+extern cell_ptr builtin_fn_cvt_to_string_lit(cell_processor_if &ci,
+                                         cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_cvt_to_integer(cell_processor_if &ci,
                                           cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_cvt_to_float(cell_processor_if &ci,

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
@@ -90,6 +90,8 @@ extern cell_ptr builtin_fn_common_nop(cell_processor_if &ci, cell_list_t &list,
                                       env_c &env);
 extern cell_ptr builtin_fn_common_macro(cell_processor_if &ci,
                                         cell_list_t &list, env_c &env);
+extern cell_ptr builtin_fn_common_exchange(cell_processor_if &ci,
+                                           cell_list_t &list, env_c &env);
 
 // Assertions
 

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
@@ -35,6 +35,8 @@ extern cell_ptr builtin_fn_env_drop(cell_processor_if &ci, cell_list_t &list,
                                     env_c &env);
 extern cell_ptr builtin_fn_env_fn(cell_processor_if &ci, cell_list_t &list,
                                   env_c &env);
+extern cell_ptr builtin_fn_env_str_set_at(cell_processor_if &ci,
+                                          cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_dict_fn(cell_processor_if &ci, cell_list_t &list,
                                    env_c &env);
 
@@ -150,7 +152,7 @@ extern cell_ptr builtin_fn_comparison_not(cell_processor_if &ci,
 extern cell_ptr builtin_fn_cvt_to_string(cell_processor_if &ci,
                                          cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_cvt_to_string_lit(cell_processor_if &ci,
-                                         cell_list_t &list, env_c &env);
+                                             cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_cvt_to_integer(cell_processor_if &ci,
                                           cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_cvt_to_float(cell_processor_if &ci,

--- a/nibi/lib/libnibi/interpreter/builtins/common.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/common.cpp
@@ -37,6 +37,16 @@ cell_ptr builtin_fn_common_len(cell_processor_if &ci, cell_list_t &list,
   return allocate_cell((int64_t)list_info.list.size());
 }
 
+cell_ptr builtin_fn_common_exchange(cell_processor_if &ci, cell_list_t &list,
+                                    env_c &env) {
+  NIBI_LIST_ENFORCE_SIZE(nibi::kw::EXCHANGE, ==, 3)
+  auto target = ci.process_cell(list[1], env);
+  auto source = ci.process_cell(list[2], env);
+  auto result = target->clone(env);
+  target->update_from(*source, env);
+  return result;
+}
+
 cell_ptr builtin_fn_common_yield(cell_processor_if &ci, cell_list_t &list,
                                  env_c &env) {
 

--- a/nibi/lib/libnibi/interpreter/builtins/conversion.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/conversion.cpp
@@ -5,7 +5,8 @@
 #include "interpreter/interpreter.hpp"
 #include "libnibi/cell.hpp"
 #include "libnibi/keywords.hpp"
-#include "macros.hpp"
+#include "libnibi/shared.hpp"
+#include "libnibi/macros.hpp"
 
 namespace nibi {
 
@@ -36,6 +37,19 @@ cell_ptr builtin_fn_cvt_to_string(cell_processor_if &ci, cell_list_t &list,
                                   env_c &env) {
   NIBI_LIST_ENFORCE_SIZE(nibi::kw::STR, ==, 2)
   return allocate_cell(ci.process_cell(list[1], env)->to_string());
+}
+
+cell_ptr builtin_fn_cvt_to_string_lit(cell_processor_if &ci, cell_list_t &list,
+                                  env_c &env) {
+  NIBI_LIST_ENFORCE_SIZE(nibi::kw::STR_LIT, ==, 2)
+
+  auto linf = ci.process_cell(list[1], env)->as_list_info();
+
+  std::string str;
+  for(auto i : linf.list) {
+    str += i->to_string(false, true);
+  }
+  return allocate_cell(str);
 }
 
 cell_ptr builtin_fn_cvt_to_integer(cell_processor_if &ci, cell_list_t &list,
@@ -101,13 +115,45 @@ cell_ptr
 cell_ptr builtin_fn_cvt_to_char(cell_processor_if &ci, cell_list_t &list,
                                 env_c &env) {
   NIBI_LIST_ENFORCE_SIZE(nibi::kw::CHAR, ==, 2)
+
   auto value = ci.process_cell(list[1], env);
+
+  auto result = allocate_cell('\0');
+
+  if (value->is_integer()) {
+    auto i = value->to_integer();
+    result->data.ch = static_cast<char>(i);
+    result->locator = list[0]->locator;
+    return result;
+  }
+
+  if (value->type != cell_type_e::STRING) {
+    throw interpreter_c::exception_c(
+        "Can not convert non-integer and non-string cell to char",
+        list[0]->locator);
+  }
+
   auto str = value->to_string();
   if (str.empty()) {
-    return allocate_cell((char)0);
+    return allocate_cell('\0');
   }
+
+  if (str[0] == '\\') {
+    if (shared::char_escape_map.find(str[0]) !=
+        shared::char_escape_map.end()) {
+      return allocate_cell(shared::char_escape_map[str[0]]);
+    }
+  }
+
+  if (str.size() > 1) {
+    throw interpreter_c::exception_c(
+        "String too large to convert into a single char",
+        list[1]->locator);
+  }
+
   return allocate_cell(str[0]);
 }
+
 
 cell_ptr builtin_fn_cvt_to_split(cell_processor_if &ci, cell_list_t &list,
                                  env_c &env) {

--- a/nibi/lib/libnibi/interpreter/builtins/conversion.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/conversion.cpp
@@ -5,8 +5,8 @@
 #include "interpreter/interpreter.hpp"
 #include "libnibi/cell.hpp"
 #include "libnibi/keywords.hpp"
-#include "libnibi/shared.hpp"
 #include "libnibi/macros.hpp"
+#include "libnibi/shared.hpp"
 
 namespace nibi {
 
@@ -40,13 +40,13 @@ cell_ptr builtin_fn_cvt_to_string(cell_processor_if &ci, cell_list_t &list,
 }
 
 cell_ptr builtin_fn_cvt_to_string_lit(cell_processor_if &ci, cell_list_t &list,
-                                  env_c &env) {
+                                      env_c &env) {
   NIBI_LIST_ENFORCE_SIZE(nibi::kw::STR_LIT, ==, 2)
 
   auto linf = ci.process_cell(list[1], env)->as_list_info();
 
   std::string str;
-  for(auto i : linf.list) {
+  for (auto i : linf.list) {
     str += i->to_string(false, true);
   }
   return allocate_cell(str);
@@ -139,21 +139,18 @@ cell_ptr builtin_fn_cvt_to_char(cell_processor_if &ci, cell_list_t &list,
   }
 
   if (str[0] == '\\') {
-    if (shared::char_escape_map.find(str[0]) !=
-        shared::char_escape_map.end()) {
+    if (shared::char_escape_map.find(str[0]) != shared::char_escape_map.end()) {
       return allocate_cell(shared::char_escape_map[str[0]]);
     }
   }
 
   if (str.size() > 1) {
     throw interpreter_c::exception_c(
-        "String too large to convert into a single char",
-        list[1]->locator);
+        "String too large to convert into a single char", list[1]->locator);
   }
 
   return allocate_cell(str[0]);
 }
-
 
 cell_ptr builtin_fn_cvt_to_split(cell_processor_if &ci, cell_list_t &list,
                                  env_c &env) {

--- a/nibi/lib/libnibi/interpreter/builtins/environment_modifiers.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/environment_modifiers.cpp
@@ -37,6 +37,32 @@ cell_ptr builtin_fn_env_alias(cell_processor_if &ci, cell_list_t &list,
   return allocate_cell(cell_type_e::NIL);
 }
 
+cell_ptr builtin_fn_env_str_set_at(cell_processor_if &ci, cell_list_t &list,
+                                   env_c &env) {
+  NIBI_LIST_ENFORCE_SIZE(nibi::kw::STR_SET_AT, ==, 4)
+
+  auto target_cell = ci.process_cell(list[1], env);
+  auto target = target_cell->as_string();
+
+  auto index = ci.process_cell(list[2], env)->as_integer();
+  auto value = ci.process_cell(list[3], env)->to_string();
+
+  while (index < 0) {
+    index = target.size() + index;
+  }
+
+  if (index >= target.size()) {
+    throw interpreter_c::exception_c("Index out of bounds", list[2]->locator);
+  }
+
+  std::string result =
+      target.substr(0, index) + value + target.substr(index + 1);
+
+  target_cell->update_from(*allocate_cell(result), env);
+
+  return target_cell;
+}
+
 cell_ptr builtin_fn_env_assignment(cell_processor_if &ci, cell_list_t &list,
                                    env_c &env) {
 

--- a/nibi/lib/libnibi/interpreter/builtins/list_commands.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/list_commands.cpp
@@ -142,7 +142,11 @@ cell_ptr builtin_fn_list_at(cell_processor_if &ci, cell_list_t &list,
 
   auto actual_idx_val = requested_idx->as_integer();
 
-  if (actual_idx_val < 0 || actual_idx_val >= list_info.list.size()) {
+  while (actual_idx_val < 0) {
+    actual_idx_val = list_info.list.size() + actual_idx_val;
+  }
+
+  if (actual_idx_val >= list_info.list.size()) {
     throw interpreter_c::exception_c("Index out of bounds (OOB)",
                                      list[2]->locator);
   }

--- a/nibi/lib/libnibi/keywords.hpp
+++ b/nibi/lib/libnibi/keywords.hpp
@@ -53,6 +53,8 @@ static constexpr const char *BW_OR = "bw-or";
 static constexpr const char *BW_XOR = "bw-xor";
 static constexpr const char *BW_NOT = "bw-not";
 static constexpr const char *STR = "str";
+static constexpr const char *STR_LIT = "str-lit";
+static constexpr const char *STR_SET_AT = "str-set-at";
 static constexpr const char *INT = "int";
 static constexpr const char *I8 = "i8";
 static constexpr const char *I16 = "i16";
@@ -76,6 +78,8 @@ static constexpr const char *MEM_CPY = "mem-cpy";
 static constexpr const char *MEM_LOAD = "mem-load";
 static constexpr const char *MEM_IS_SET = "mem-is-set";
 static constexpr const char *ALIAS = "alias";
+static constexpr const char *EXCHANGE = "exchange";
+
 
 } // namespace kw
 } // namespace nibi

--- a/nibi/lib/libnibi/keywords.hpp
+++ b/nibi/lib/libnibi/keywords.hpp
@@ -80,6 +80,5 @@ static constexpr const char *MEM_IS_SET = "mem-is-set";
 static constexpr const char *ALIAS = "alias";
 static constexpr const char *EXCHANGE = "exchange";
 
-
 } // namespace kw
 } // namespace nibi

--- a/nibi/lib/libnibi/shared.hpp
+++ b/nibi/lib/libnibi/shared.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace nibi {
+
+namespace shared {
+
+static std::unordered_map<char, char> char_escape_map = {
+    {'n', '\n'},  {'t', '\t'},  {'r', '\r'}, {'a', '\a'},
+    {'b', '\b'},  {'v', '\v'},  {'?', '\?'}, {'"', '\"'},
+    {'\'', '\''}, {'\\', '\\'}, {'0', '\0'}};
+
+}
+}

--- a/nibi/lib/libnibi/shared.hpp
+++ b/nibi/lib/libnibi/shared.hpp
@@ -10,4 +10,4 @@ static std::unordered_map<char, char> char_escape_map = {
     {'\'', '\''}, {'\\', '\\'}, {'0', '\0'}};
 
 }
-}
+} // namespace nibi

--- a/nibi/modules/net/examples/client.nibi
+++ b/nibi/modules/net/examples/client.nibi
@@ -29,7 +29,7 @@
   (exit 1)
 ])
 
-(:= read_buffer (str (<|> "" 1024)))
+(:= read_buffer (str-lit (<|> " " 32)))
 
 (:= n_bytes_read (net::read socket_fd read_buffer))
 

--- a/nibi/modules/net/examples/server.nibi
+++ b/nibi/modules/net/examples/server.nibi
@@ -36,9 +36,11 @@
   (exit 1)
 ])
 
-(:= read_buffer (str (<|> "" 1024)))
+(:= read_buffer (str-lit (<|> " " 32)))
 
 (:= n_bytes_read (net::read new_conn_fd read_buffer))
+
+(str-set-at read_buffer n_bytes_read (char "\0"))
 
 (io::println "Read in: " n_bytes_read " bytes. Data: " read_buffer)
 

--- a/nibi/modules/net/lib.cpp
+++ b/nibi/modules/net/lib.cpp
@@ -47,9 +47,5 @@ int64_t nibi_net_accept(int64_t fd, void *saddr) {
 }
 
 int64_t nibi_net_read(int64_t fd, char *buffer, int64_t buffer_len) {
-  auto read_in = read(fd, buffer, buffer_len);
-  if (read_in < buffer_len) {
-    buffer[read_in] = '\0';
-  }
-  return read_in;
+  return read(fd, buffer, buffer_len);
 }

--- a/nibi/std/strings.nibi
+++ b/nibi/std/strings.nibi
@@ -1,12 +1,23 @@
-# \brief Update a string at a given index
-# \param _str The string to update
-# \param _idx Index to update at
-# \param _val Value to assign 
-(fn str_set_idx[_str _idx _val] [
-  (assert (is_string _str) "Given item is not a string")
-  (assert (is_int _idx) "Index into string must be an integer type")
-  (:= _x (split _str))
-  (set (at _x _idx) _val)
-  (set _str (str-lit _x))
-  (<- _str)
-])
+# Author: Josh Bosley
+#
+# About:
+# Standard string operations
+#
+# Depends on std/types.nibi:
+# - is_string
+# - is_char
+
+# \brief Split a string by a delimiter
+(:= string_split (fn [_str _delim] [
+  (assert (is_string _str))
+  (assert (or (is_string _delim) (is_char _delim)))
+  (:= _res [])
+  (:= _chunk "")
+  (:= _as_list (split _str))
+  (iter _as_list i
+    (if (eq i _delim) (|< _res (exchange _chunk ""))
+    (set _chunk (+ _chunk i))))
+  (if (len _chunk) (|< _res _chunk))
+  (<- _res)
+]))
+

--- a/nibi/std/strings.nibi
+++ b/nibi/std/strings.nibi
@@ -1,0 +1,12 @@
+# \brief Update a string at a given index
+# \param _str The string to update
+# \param _idx Index to update at
+# \param _val Value to assign 
+(fn str_set_idx[_str _idx _val] [
+  (assert (is_string _str) "Given item is not a string")
+  (assert (is_int _idx) "Index into string must be an integer type")
+  (:= _x (split _str))
+  (set (at _x _idx) _val)
+  (set _str (str-lit _x))
+  (<- _str)
+])

--- a/nibi/std/types.nibi
+++ b/nibi/std/types.nibi
@@ -45,6 +45,9 @@
   (<- false)
 ])
 
+(fn is_char [_x]
+  (eq (type _x) "char"))
+
 (fn is_string [_x]
   (eq (type _x) "string"))
 

--- a/tests/test_scripts/tests/0_exchange.nibi
+++ b/tests/test_scripts/tests/0_exchange.nibi
@@ -1,0 +1,7 @@
+(:= v 0)
+(loop (:= x 0) (< x 10) (set x (+ x 1))
+  (assert (eq x (exchange v (+ 1 x)))))
+
+(set v 0)
+(loop (:= x 0) (< x 10) (exchange x (+ 1 x))
+  (assert (eq x (exchange v (+ 1 x)))))

--- a/tests/test_scripts/tests/0_lists.nibi
+++ b/tests/test_scripts/tests/0_lists.nibi
@@ -85,3 +85,14 @@
 
 
 (assert (eq [1 2 44] other_list))
+
+# Negative indexing test
+
+(:= z [1 2 3 4 5])
+
+(set (at z -2) 0)
+(assert (eq [1 2 3 0 5] z))
+
+(set (at z -8) 1)
+(assert (eq [1 2 1 0 5] z))
+

--- a/tests/test_scripts/tests/0_strings.nibi
+++ b/tests/test_scripts/tests/0_strings.nibi
@@ -1,0 +1,28 @@
+
+(:= x "..........")
+(str-set-at x 0 "X")
+
+(assert (eq x "X........."))
+
+(str-set-at x (- (len x) 1) "X")
+
+(assert (eq x "X........X"))
+
+(assert (eq (str-set-at "abc" 1 "X") "aXc"))
+(assert (eq (str-set-at "abc" 0 "X") "Xbc"))
+(assert (eq (str-set-at "abc" 2 "X") "abX"))
+
+# OOB
+(try [
+  (str-set-at "abc" 3 "X")
+  (exit 1)
+] (nop))
+
+# Negative values can just wrap around until
+# they are positive and then they are treated
+# as positive values.
+(assert (eq (str-set-at "abc" -1 "X") "abX"))
+(assert (eq (str-set-at "abc" -2 "X") "aXc"))
+(assert (eq (str-set-at "abc" -3 "X") "Xbc"))
+(assert (eq (str-set-at "abc" -4 "X") "abX"))
+(assert (eq (str-set-at "abc" -5 "X") "aXc"))

--- a/tools/syntax/nibi.vim
+++ b/tools/syntax/nibi.vim
@@ -28,7 +28,7 @@ syn match nibiNumber '\d\+' contained
 
 syn keyword nibiFunc set fn drop try throw assert alias
 syn keyword nibiFunc env at iter eval quote loop exit quote import use macro
-syn keyword nibiFunc int str float split type len clone nop dict
+syn keyword nibiFunc int str char float split type len clone nop dict
 syn keyword nibiFunc i8 i16 i32 i64 u8 u16 u32 u64 f32 f64
 syn keyword nibiQuickType true false nil nan inf
 
@@ -39,7 +39,7 @@ syn match nibiKeyword '$args\|$e' contained
 syn match nibiFunc '\(eq\|>\|<\|neq\|<=\|>=\|and\|or\|not\|if\|+\|-\|*\|/\)' contained
 syn match nibiFunc '\(bw-and\|bw-or\|bw-xor\|bw-not\|bw-lsh\|bw-rsh\|<-\)' contained
 syn match nibiFunc '\(extern-call\|mem-new\|mem-del\|mem-cpy\|mem-load\)' contained
-syn match nibiFunc '\(mem-is-set\)' contained
+syn match nibiFunc '\(mem-is-set\|str-lit\|exchange\|str-set-at\)' contained
 syn match nibiFunc ':=' contained
 syn match nibiFunc '<<|' contained
 syn match nibiFunc '|>>' contained

--- a/tools/syntax/nibi.vim
+++ b/tools/syntax/nibi.vim
@@ -26,6 +26,8 @@ syn match nibiComment "#.*$"
 syn match nibiIdentifier '[a-zA-Z_][a-zA-Z0-9_]*' contained
 syn match nibiNumber '\d\+' contained
 
+syn match nibiFunc '\(str-lit\|str-set-at\)' contained
+
 syn keyword nibiFunc set fn drop try throw assert alias
 syn keyword nibiFunc env at iter eval quote loop exit quote import use macro
 syn keyword nibiFunc int str char float split type len clone nop dict
@@ -39,7 +41,7 @@ syn match nibiKeyword '$args\|$e' contained
 syn match nibiFunc '\(eq\|>\|<\|neq\|<=\|>=\|and\|or\|not\|if\|+\|-\|*\|/\)' contained
 syn match nibiFunc '\(bw-and\|bw-or\|bw-xor\|bw-not\|bw-lsh\|bw-rsh\|<-\)' contained
 syn match nibiFunc '\(extern-call\|mem-new\|mem-del\|mem-cpy\|mem-load\)' contained
-syn match nibiFunc '\(mem-is-set\|str-lit\|exchange\|str-set-at\)' contained
+syn match nibiFunc '\(mem-is-set\|exchange\)' contained
 syn match nibiFunc ':=' contained
 syn match nibiFunc '<<|' contained
 syn match nibiFunc '|>>' contained


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [X] Branch name details the work done for the PR
- [X] CI tests have passed
- [X] An admin has reviewed and accepted the PR
- [X] Clang format has been run on changes (`run ./tools/format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Unions end in `_u`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)
- Type names that define a particular type of pointer end in `_ptr`

The above is just a loose formatting that has been used already throughout the C++ source code of Nibi,
and we would like to keep things mostly uniform. In the future, an actual style guide may be created. 

## Description of work:

Please enter a description of your work here:
```
- exchange, str-set-at, and str-lit created
- char now converts integer values to their char representation
- std/strings.nibi created with split functionality
- `at` updated to support negative indexing with continuous wrapping
- networking module example updated to utilize new functionality 
```
