### PR TITLE
126.defer

### DIFF
--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -56,6 +56,7 @@ The following table contains the various commands available in this programming 
 | `alias`         | Use a new symbol to refer to the data behind another | `nil` |
 | `exchange` | Update the value of a cell and return the old value of the cell | variable
 | `str-set-at` | Update a string by inserting a value at a given index (negative indexing permitted) | updated string
+| `defer`         | Defer an instruction to be executed at the end of the current context | `nil`
 
 | Type Commands | Description | Returns |
 | ------------- | ----------- | ------- |

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -804,10 +804,12 @@ Example:
 | Instruction to defer |
 
 At the end of the execution context in which the statement is defined, all
-instructions deferred will be executed in-order.
+instructions deferred will be executed in-order. If an instruction given
+to defer is a data list `[]` then all items within the instruction list
+will be executed.
 
 ```
-( defer < () .. > )
+( defer < () [] .. > )
 ```
 
 ### Macro

--- a/docs/LANGUAGE.md
+++ b/docs/LANGUAGE.md
@@ -56,7 +56,7 @@ The following table contains the various commands available in this programming 
 | `alias`         | Use a new symbol to refer to the data behind another | `nil` |
 | `exchange` | Update the value of a cell and return the old value of the cell | variable
 | `str-set-at` | Update a string by inserting a value at a given index (negative indexing permitted) | updated string
-| `defer`         | Defer an instruction to be executed at the end of the current context | `nil`
+| `defer`         | Defer an instruction to be executed at the end of the current execution context | `nil`
 
 | Type Commands | Description | Returns |
 | ------------- | ----------- | ------- |
@@ -81,8 +81,8 @@ The following table contains the various commands available in this programming 
 | --------------- | ----------- | ------- |
 | `mem-new`       | Allocate some memory manually on the heap | Pointer cell |
 | `mem-del`       | Delete some memory on the heap | Pointer cell |
-| `mem-acquire`   | Declare that an unowned pointer is owned | The owned pointer |
-| `mem-abandon`   | Declare that the pointer is not owned by the nibi runtime | The pointer |
+| `mem-cpy`       | Copy a memory object | Pointer cell |
+| `mem-load`      | Load a piece of memory as a cell type | Converted cell |
 | `mem-is-set`    | Check if a cell pointer has its pointer set to a space in memory | T/F |
 
 | List Commands | Description | Returns |
@@ -129,6 +129,11 @@ The following table contains the various commands available in this programming 
 
 The table above provides an organized and concise overview of the available instructions in this programming language, along with their descriptions and return values.
 
+# Execution contexts
+
+Execution contexts dictate the length of time a defined variable exits. When the context is exited, all declared variables are removed.
+Instructions that create contexts within the global context are as follows: `fn` `if` `try`, and `loop`. If a variable is defined in one
+of these instructions, then the variable will be removed.
 
 # Type Prompting
 
@@ -263,8 +268,6 @@ Example:
 ( <- < RD S () [] > )
 ```
 
-
-
 ### If / Else
 
 Keyword: `if`
@@ -330,7 +333,7 @@ Variable Number of Arguments:
 Using the `:args` tag as the only argument to a function, a list of arguments of any size may be given. 
 
 Example:
-```scheme
+```lisp
 (use "io")
 
 (fn vargs [:args] [
@@ -348,7 +351,6 @@ Example:
 (vargs 1)
 (vargs)
 ```
-
 
 ### Import
 
@@ -437,9 +439,6 @@ Example:
 ( exit < NU S () > )
 ```
 
-
-
-
 ### Eval
 
 Keyword: `eval`
@@ -525,7 +524,6 @@ Example 2 (With list):
 ( split < S [] > < NU S () > )
 ```
 
-
 ### Type
 
 Keyword: `type`
@@ -582,7 +580,6 @@ Example:
 ```
 (nop)
 ```
-
 
 ## List Instructions
 
@@ -801,6 +798,17 @@ Example:
 ( bw-not <() NU> )
 ```
 
+### Defer
+
+| arg 1 .. n |
+| Instruction to defer |
+
+At the end of the execution context in which the statement is defined, all
+instructions deferred will be executed in-order.
+
+```
+( defer < () .. > )
+```
 
 ### Macro
 
@@ -954,19 +962,17 @@ Example:
 - Keyword: `mem-cpy`
   - Copies data in memory.
   - If the first item is a standard "trivial" cell (direct C-Type integration), it will be copied to the heap at a given destination pointer.
-  - For this to succeed, the destination pointer must be `owned`.
-  - If the first item is a pointer cell, the data will be copied to the destination if and only if the source and destination pointers are `owned`.
+  - If the first item is a pointer cell, the data will be copied to the destination.
   - In the event that the destination value has already been allocated, that data will be automatically freed before the copy takes place.
 
 - Keyword: `mem-load`
   - Attempts to load a value from memory as a regular, trivial cell.
   - Requires the first argument to be a cell `type tag` (mentioned above) that indicates how much space to load from memory and how to represent it as a cell.
-  - The second parameter must be a ptr cell. This ptr cell does not need to be owned for the operation to take place.
+  - The second parameter must be a ptr cell.
 
 - Keyword: `mem-is-set`
   - Checks if a ptr cell has been set or if it's not pointing to anything.
   - Returns T/F.
-
 
 # Modules
 

--- a/nibi/lib/libnibi/interfaces/cell_processor_if.hpp
+++ b/nibi/lib/libnibi/interfaces/cell_processor_if.hpp
@@ -42,6 +42,18 @@ public:
   //! \brief Load a module
   //! \param module_name The name of the module to load
   virtual void load_module(cell_ptr &module_name) = 0;
+
+  //! \brief Indicate that there is a new execution context
+  virtual void push_ctx() = 0;
+
+  //! \brief Exit the current execution context
+  //! \pram env Environment to use for any ctx exiting
+  //!       instructions
+  virtual void pop_ctx(env_c &env) = 0;
+
+  //! \brief Defer an execution of a cell until the
+  //!        current ctx is exited
+  virtual void defer_execution(cell_ptr ins) = 0;
 };
 
 } // namespace nibi

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.cpp
@@ -174,6 +174,9 @@ static function_info_s builtin_common_macro_inf = {
 static function_info_s builtin_common_exchange_inf = {
     nibi::kw::EXCHANGE, builtin_fn_common_exchange,
     function_type_e::BUILTIN_CPP_FUNCTION};
+static function_info_s builtin_common_defer_inf = {
+    nibi::kw::DEFER, builtin_fn_common_defer,
+    function_type_e::BUILTIN_CPP_FUNCTION};
 
 // conversion functions
 
@@ -306,6 +309,7 @@ static function_router_t keyword_map = {
     {nibi::kw::NOP, builtin_common_nop_inf},
     {nibi::kw::MACRO, builtin_common_macro_inf},
     {nibi::kw::EXCHANGE, builtin_common_exchange_inf},
+    {nibi::kw::DEFER, builtin_common_defer_inf},
     {nibi::kw::BW_LSH, builtin_bitwise_lsh_inf},
     {nibi::kw::BW_RSH, builtin_bitwise_rsh_inf},
     {nibi::kw::BW_AND, builtin_bitwise_and_inf},

--- a/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
+++ b/nibi/lib/libnibi/interpreter/builtins/builtins.hpp
@@ -92,6 +92,8 @@ extern cell_ptr builtin_fn_common_macro(cell_processor_if &ci,
                                         cell_list_t &list, env_c &env);
 extern cell_ptr builtin_fn_common_exchange(cell_processor_if &ci,
                                            cell_list_t &list, env_c &env);
+extern cell_ptr builtin_fn_common_defer(cell_processor_if &ci,
+                                        cell_list_t &list, env_c &env);
 
 // Assertions
 

--- a/nibi/lib/libnibi/interpreter/builtins/common.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/common.cpp
@@ -53,8 +53,9 @@ cell_ptr builtin_fn_common_defer(cell_processor_if &ci, cell_list_t &list,
 
   for (auto it = list.begin() + 1; it != list.end(); ++it) {
     if ((*it)->type != cell_type_e::LIST) {
-      throw interpreter_c::exception_c("Defer command requires all parameters to be of type LIST",
-                                       (*it)->locator);
+      throw interpreter_c::exception_c(
+          "Defer command requires all parameters to be of type LIST",
+          (*it)->locator);
     }
     ci.defer_execution(*it);
   }

--- a/nibi/lib/libnibi/interpreter/builtins/common.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/common.cpp
@@ -49,8 +49,15 @@ cell_ptr builtin_fn_common_exchange(cell_processor_if &ci, cell_list_t &list,
 
 cell_ptr builtin_fn_common_defer(cell_processor_if &ci, cell_list_t &list,
                                  env_c &env) {
-  NIBI_LIST_ENFORCE_SIZE(nibi::kw::DEFER, ==, 2)
-  ci.defer_execution(list[1]);
+  NIBI_LIST_ENFORCE_SIZE(nibi::kw::DEFER, >=, 2)
+
+  for (auto it = list.begin() + 1; it != list.end(); ++it) {
+    if ((*it)->type != cell_type_e::LIST) {
+      throw interpreter_c::exception_c("Defer command requires all parameters to be of type LIST",
+                                       (*it)->locator);
+    }
+    ci.defer_execution(*it);
+  }
   return allocate_cell(cell_type_e::NIL);
 }
 

--- a/nibi/lib/libnibi/interpreter/builtins/common.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/common.cpp
@@ -47,6 +47,13 @@ cell_ptr builtin_fn_common_exchange(cell_processor_if &ci, cell_list_t &list,
   return result;
 }
 
+cell_ptr builtin_fn_common_defer(cell_processor_if &ci, cell_list_t &list,
+                                 env_c &env) {
+  NIBI_LIST_ENFORCE_SIZE(nibi::kw::DEFER, ==, 2)
+  ci.defer_execution(list[1]);
+  return allocate_cell(cell_type_e::NIL);
+}
+
 cell_ptr builtin_fn_common_yield(cell_processor_if &ci, cell_list_t &list,
                                  env_c &env) {
 
@@ -81,6 +88,8 @@ cell_ptr builtin_fn_common_loop(cell_processor_if &ci, cell_list_t &list,
 
   auto body = (*it);
 
+  ci.push_ctx();
+
   auto loop_env = env_c(&env);
 
   ci.process_cell(pre_condition, loop_env);
@@ -102,6 +111,8 @@ cell_ptr builtin_fn_common_loop(cell_processor_if &ci, cell_list_t &list,
     ci.process_cell(post_condition, loop_env);
   }
 
+  ci.pop_ctx(loop_env);
+
   return result;
 }
 
@@ -119,16 +130,21 @@ cell_ptr builtin_fn_common_if(cell_processor_if &ci, cell_list_t &list,
 
   auto if_env = env_c(&env);
 
+  ci.push_ctx();
+
   auto condition_result = ci.process_cell(condition, if_env);
 
   if (condition_result->as_integer() > 0) {
+    ci.pop_ctx(if_env);
     return ci.process_cell(true_condition, if_env, true);
   }
 
   if (list.size() == 4) {
     std::advance(it, 1);
+    ci.pop_ctx(if_env);
     return ci.process_cell((*it), if_env, true);
   }
+  ci.pop_ctx(if_env);
 
   return ci.get_last_result();
 }

--- a/nibi/lib/libnibi/interpreter/builtins/excepts.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/excepts.cpp
@@ -49,16 +49,23 @@ cell_ptr builtin_fn_except_try(cell_processor_if &ci, cell_list_t &list,
   std::advance(it, 1);
   auto recover_cell = (*it);
 
+  env_c try_env(&env);
+  ci.push_ctx();
+
+  cell_ptr res{nullptr};
+
   try {
     // Call execute with the process_data_cell flag set to true
     // which will allow us to walk over multiple cells and catch on them
-    return ci.process_cell(attempt_cell, env, true);
+    res = ci.process_cell(attempt_cell, env, true);
   } catch (interpreter_c::exception_c &e) {
-    return handle_thrown_error_in_try(e.what(), recover_cell, ci, env);
+    res = handle_thrown_error_in_try(e.what(), recover_cell, ci, try_env);
   } catch (cell_access_exception_c &e) {
-    return handle_thrown_error_in_try(e.what(), recover_cell, ci, env);
+    res = handle_thrown_error_in_try(e.what(), recover_cell, ci, try_env);
   }
-  return allocate_cell(cell_type_e::NIL);
+
+  ci.pop_ctx(try_env);
+  return res;
 }
 
 cell_ptr builtin_fn_except_throw(cell_processor_if &ci, cell_list_t &list,

--- a/nibi/lib/libnibi/interpreter/builtins/lambdas.cpp
+++ b/nibi/lib/libnibi/interpreter/builtins/lambdas.cpp
@@ -73,7 +73,9 @@ cell_ptr execute_suspected_lambda(cell_processor_if &ci, cell_list_t &list,
 
   auto &body = lambda_info.body->as_list_info();
 
+  ci.push_ctx();
   cell_ptr result = ci.process_cell(lambda_info.body, lambda_env, true);
+  ci.pop_ctx(lambda_env);
 
   // Because we have pointers to parametrs stored we don't want the environment
   // to free them, so we manually remove them here before

--- a/nibi/lib/libnibi/interpreter/interpreter.hpp
+++ b/nibi/lib/libnibi/interpreter/interpreter.hpp
@@ -80,7 +80,22 @@ public:
 
   virtual env_c &get_env() override { return interpreter_env; }
 
+  virtual void push_ctx() override { ctxs_.push(ctx_s{}); }
+
+  virtual void pop_ctx(env_c &env) override;
+
+  virtual void defer_execution(cell_ptr ins) override {
+    if (ctxs_.empty()) {
+      push_ctx();
+    }
+    ctxs_.top().deferred.push_back(ins);
+  }
+
 private:
+  struct ctx_s {
+    std::vector<cell_ptr> deferred;
+  };
+
   // The last item that was processed
   cell_ptr last_result_{nullptr};
 
@@ -107,6 +122,8 @@ private:
   void halt_with_error(error_c error);
 
   std::stack<cell_ptr> call_stack_;
+
+  std::stack<ctx_s> ctxs_;
 
 #if PROFILE_INTERPRETER
   struct profile_info_s {

--- a/nibi/lib/libnibi/keywords.hpp
+++ b/nibi/lib/libnibi/keywords.hpp
@@ -79,6 +79,7 @@ static constexpr const char *MEM_LOAD = "mem-load";
 static constexpr const char *MEM_IS_SET = "mem-is-set";
 static constexpr const char *ALIAS = "alias";
 static constexpr const char *EXCHANGE = "exchange";
+static constexpr const char *DEFER = "defer";
 
 } // namespace kw
 } // namespace nibi

--- a/tests/test_scripts/tests/0_defer.nibi
+++ b/tests/test_scripts/tests/0_defer.nibi
@@ -1,0 +1,17 @@
+(use "io")
+
+(fn x [] [
+  (:= x (mem-new 16))
+  (defer (mem-del x))
+  (nop)
+  (nop)
+  (nop)
+  (nop)
+  (nop)
+  (nop)
+  (assert (eq true (mem-is-set x)))
+])
+
+(x)
+
+(io::println "COMPLETE")

--- a/tests/test_scripts/tests/0_try.nibi
+++ b/tests/test_scripts/tests/0_try.nibi
@@ -2,10 +2,13 @@
 (drop x)
 (try (drop x) (nop))
 
+(:= a 0)
+(:= b 0)
+(:= c 0)
 (try [
-  (:= a 0)
-  (:= b 1)
-  (:= c 2)
+  (set a 0)
+  (set b 1)
+  (set c 2)
 ] (assert 0 "Exception thrown for some reason") )
 
 (assert (eq a 0) "failed to exec all items in try list")
@@ -48,6 +51,7 @@
 # Here we do something similar, but we attempt to update with `set` a value that doesn't exist
 # so we should retrieve the last thing completed in the recovery case 
 
-(assert (eq 2 (:= check1 (try (set i_dont_exist 90) (:= check2 v)))) "Failed to get value from try statement")
+(:= check2 nil)
+(assert (eq 2 (:= check1 (try (set i_dont_exist 90) (set check2 v)))) "Failed to get value from try statement")
 
 (assert (eq v check2) "v and check2 were not equalififif")

--- a/tests/test_scripts/tests/0_try_throw.nibi
+++ b/tests/test_scripts/tests/0_try_throw.nibi
@@ -1,8 +1,9 @@
 (:= message "i like dogs")
 
+(:= result nil)
 (try
   (throw message)
-  (:= result $e)
+  (set result $e)
 )
 
 (assert (eq message result) "Throw did not give the correct result")

--- a/tests/test_valgrind/defer.nibi
+++ b/tests/test_valgrind/defer.nibi
@@ -1,0 +1,17 @@
+(use "io")
+
+(fn x [] [
+  (:= x (mem-new 16))
+  (defer (mem-del x))
+  (nop)
+  (nop)
+  (nop)
+  (nop)
+  (nop)
+  (nop)
+  (assert (eq true (mem-is-set x)))
+])
+
+(x)
+
+(io::println "COMPLETE")

--- a/tools/syntax/nibi.vim
+++ b/tools/syntax/nibi.vim
@@ -41,7 +41,7 @@ syn match nibiKeyword '$args\|$e' contained
 syn match nibiFunc '\(eq\|>\|<\|neq\|<=\|>=\|and\|or\|not\|if\|+\|-\|*\|/\)' contained
 syn match nibiFunc '\(bw-and\|bw-or\|bw-xor\|bw-not\|bw-lsh\|bw-rsh\|<-\)' contained
 syn match nibiFunc '\(extern-call\|mem-new\|mem-del\|mem-cpy\|mem-load\)' contained
-syn match nibiFunc '\(mem-is-set\|exchange\)' contained
+syn match nibiFunc '\(mem-is-set\|exchange\|defer\)' contained
 syn match nibiFunc ':=' contained
 syn match nibiFunc '<<|' contained
 syn match nibiFunc '|>>' contained


### PR DESCRIPTION
## (ﾉ◕ヮ◕)ﾉ*✲ﾟ*｡⋆ You've made a PR!

Before the code PR is merged, please ensure that the following checklist is completed. 

- [X] Branch name details the work done for the PR
- [ ] CI tests have passed
- [ ] An admin has reviewed and accepted the PR
- [X] Clang format has been run on changes (`run ./tools/format.sh`)

Please be sure that the code follows the style as follows:

- Everything in `snake_case`
- Classes end in `_c` (unless its an interface, then end in `_if`)
- Structs end in `_s`
- Unions end in `_u`
- Enumerations end in `_e`
- Type names that are redefined via `using` end in `_t` (always use `using` - not `typedef`)
- Type names that define a particular type of pointer end in `_ptr`

The above is just a loose formatting that has been used already throughout the C++ source code of Nibi,
and we would like to keep things mostly uniform. In the future, an actual style guide may be created. 

## Description of work:

Please enter a description of your work here:
```
Added "execution contexts" to the interpreter and a means to defer the execution of instructions until the end of those contexts. 
```
